### PR TITLE
Add New Relic connector

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,7 @@ repos:
     hooks:
       - id: prettier
         name: Make code pretty
+        exclude: .*\.(nrql|graphql)
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.8.6

--- a/src/apis/braze/connector.py
+++ b/src/apis/braze/connector.py
@@ -3,8 +3,9 @@ API clients for Braze.
 """
 
 import enum
-import requests
 import json
+
+import requests
 
 
 class Brand(enum.StrEnum):

--- a/src/apis/jira/connector.py
+++ b/src/apis/jira/connector.py
@@ -12,9 +12,9 @@ See the following documentation:
 """
 
 import base64
+import json
 
 import requests
-import json
 
 
 class JiraConnector:

--- a/src/apis/new_relic/__init__.py
+++ b/src/apis/new_relic/__init__.py
@@ -1,0 +1,11 @@
+"""
+API clients for New Relic.
+
+https://docs.newrelic.com/docs/apis/intro-apis/introduction-new-relic-apis/
+"""
+
+from src.apis.new_relic.connector import NewRelicConnector
+
+__all__ = [
+    "NewRelicConnector",
+]

--- a/src/apis/new_relic/connector.py
+++ b/src/apis/new_relic/connector.py
@@ -1,0 +1,84 @@
+"""
+API clients for New Relic.
+"""
+
+import pathlib
+from typing import Any
+
+import requests
+
+HERE = pathlib.Path(__file__).parent
+BASE_URL = "https://api.newrelic.com/graphql/"
+REQUEST_TIMEOUT_SECONDS = 10
+NRQL_WRAPPER = (HERE / "nrql-wrapper.graphql").read_text(encoding="utf-8")
+
+
+class NewRelicConnector:
+    """
+    Bridge class for the New Relic NerdGraph (GraphQL) API.
+    """
+
+    def __init__(self, account_id: str, api_key: str):
+        self.base_url = BASE_URL
+        self.account_id = account_id
+        self.api_key = api_key
+
+    @property
+    def request_headers(self) -> dict:
+        """
+        Default request headers.
+        """
+        return {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "API-Key": self.api_key,
+        }
+
+    def query(self, query: str) -> list[dict]:
+        """
+        Execute a NRQL query and return the result.
+        """
+
+        # fmt: off
+        query_ = (
+            NRQL_WRAPPER
+                .replace("{{account_id}}", self.account_id)
+                .replace("{{query}}", query.replace("\n", " ").strip())
+        )
+        # fmt: on
+
+        return _get_and_unpack(
+            url=self.base_url,
+            headers=self.request_headers,
+            params={"query": query_},
+        )
+
+
+def _get_and_unpack(
+    url: str,
+    headers: dict | None = None,
+    params: dict | None = None,
+) -> list[dict]:
+    if response := get(url, headers, params):
+        return response["data"]["actor"]["account"]["nrql"]["results"]
+    return []
+
+
+def get(
+    url: str,
+    headers: dict | None = None,
+    params: dict | None = None,
+) -> Any:
+    """
+    Perform a GET request and return the JSON response.
+    """
+
+    response = requests.get(
+        url=url,
+        headers=headers,
+        params=params,
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+
+    return response.json()

--- a/src/apis/new_relic/main.py
+++ b/src/apis/new_relic/main.py
@@ -1,0 +1,26 @@
+"""
+Manual testing for the API clients.
+"""
+
+import os
+
+import dotenv
+
+from src.apis import new_relic
+
+dotenv.load_dotenv()
+
+
+def main() -> None:
+    """
+    Manually test the API client.
+    """
+    new_relic_connector = new_relic.NewRelicConnector(
+        account_id=os.getenv("NEW_RELIC__ACCOUNT_ID"),
+        api_key=os.getenv("NEW_RELIC__API_KEY"),
+    )
+    print(new_relic_connector)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/apis/new_relic/nrql-wrapper.graphql
+++ b/src/apis/new_relic/nrql-wrapper.graphql
@@ -1,0 +1,9 @@
+{
+  actor {
+    account(id: {{account_id}}) {
+      nrql(query: "{{query}}") {
+        results
+      }
+    }
+  }
+}

--- a/src/apis/tempo/main.py
+++ b/src/apis/tempo/main.py
@@ -12,12 +12,12 @@ Arguments expected are, in order:
 https://community.atlassian.com/t5/Jira-questions/What-is-the-simplest-way-to-connect-to-Tempo-API/qaq-p/1280418
 """
 
-import requests
 import json
 import sys
 import os
 
 import dotenv
+import requests
 
 dotenv.load_dotenv()
 

--- a/src/apis/vault/connector.py
+++ b/src/apis/vault/connector.py
@@ -2,8 +2,9 @@
 API clients for HashiCorp Vault.
 """
 
-import requests
 import json
+
+import requests
 
 
 class VaultConnector:

--- a/tests/apis/new_relic/test__connector.py
+++ b/tests/apis/new_relic/test__connector.py
@@ -1,0 +1,105 @@
+import http
+import textwrap
+
+import pytest
+import requests
+from requests.exceptions import RequestException
+
+from src.apis.new_relic import connector
+
+
+class MockResponse:
+    def __init__(self, data: dict, code: int):
+        self.data = data
+        self.code = code
+
+    def json(self):
+        return self.data
+
+    def raise_for_status(self):
+        if not (200 <= self.code < 300):
+            raise RequestException("I'm a doctor, Jim, not a server!")
+
+
+@pytest.fixture
+def connection() -> connector.NewRelicConnector:
+    return connector.NewRelicConnector(
+        account_id="123456789",
+        api_key="NRAK-A1B2C3D4",
+    )
+
+
+def test__connector_properties_are_correct(
+    connection: connector.NewRelicConnector,
+):
+    assert connection.base_url == "https://api.newrelic.com/graphql/"
+    assert connection.request_headers == {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "API-Key": "NRAK-A1B2C3D4",
+    }
+
+
+def test__queries_are_constructed_correctly(
+    monkeypatch: pytest.MonkeyPatch,
+    connection: connector.NewRelicConnector,
+):
+    def mock_get(url: str, headers: dict, params: dict, timeout: int):
+        assert url == "https://api.newrelic.com/graphql/"
+        assert timeout == 10
+        assert headers == {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "API-Key": "NRAK-A1B2C3D4",
+        }
+        assert params == {
+            "query": textwrap.dedent(
+                """\
+                {
+                  actor {
+                    account(id: 123456789) {
+                      nrql(query: "some query with a new line   and some spaces") {
+                        results
+                      }
+                    }
+                  }
+                }
+                """
+            )
+        }
+
+        return MockResponse({}, http.HTTPStatus.OK)
+
+    monkeypatch.setattr(requests, "get", mock_get)
+    connection.query("some query\nwith a new line\n  and some spaces")
+
+
+def test__query_results_are_returned_correctly(
+    monkeypatch: pytest.MonkeyPatch,
+    connection: connector.NewRelicConnector,
+):
+    query = """from SomeTable select count(*)"""
+    results = [{"count", 123}]
+    response = {"data": {"actor": {"account": {"nrql": {"results": results}}}}}
+
+    monkeypatch.setattr(
+        requests,
+        "get",
+        lambda *args, **kwargs: MockResponse(response, http.HTTPStatus.OK),
+    )
+
+    assert connection.query(query) == results
+
+
+def test__bad_queries_raise_an_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    connection: connector.NewRelicConnector,
+):
+    monkeypatch.setattr(
+        requests,
+        "get",
+        lambda *args, **kwargs: MockResponse({}, http.HTTPStatus.BAD_REQUEST),
+    )
+
+    with pytest.raises(RequestException):
+        connection.query("something bad")


### PR DESCRIPTION
## Summary by Sourcery

Adds a New Relic connector to query the New Relic GraphQL API.

New Features:
- Introduces a New Relic connector to query the New Relic GraphQL API.
- Adds a test suite for the New Relic connector.
- Adds a manual test script for the New Relic connector.
- Adds a GraphQL wrapper for NRQL queries to the New Relic connector.

Tests:
- Adds tests for the New Relic connector, ensuring correct query construction and result handling.