### PR TITLE
Only use one Python version specifier in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: 🐍 Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version-file: "pyproject.toml"
 
       - name: 🔨 Install dependencies
         run: pip install -r requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic.dependencies = {file = ["requirements.txt"]}
 
 
 [tool.pytest.ini_options]
-addopts = "--cov=src --cov-fail-under=80"
+addopts = "--cov=src"
 testpaths = ["tests"]
 
 
@@ -43,8 +43,13 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 # https://github.com/astral-sh/ruff/issues/4368
 [tool.ruff.lint.extend-per-file-ignores]
+"*.py" = [
+    "S105",    #  Possible hardcoded password assigned to variable
+    "S106",    #  Possible hardcoded password assigned to argument
+    "S113",    #  Probable use of `requests` call without timeout
+    "PLR0913", #  Too many arguments in function definition
+]
 "tests/**/*.py" = [
     "S101",    #  Use of `assert` detected
     "PLR2004", #  Magic value used in comparison
-    "PLR0913", #  Too many arguments in function definition
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,50 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "testing-apis"
+version = "0.0.0"
+description = "Testing REST APIs either for personal projects or for work."
+authors = [{name = "Bilbottom"}]
+readme = "README.md"
+requires-python = ">=3.11"
+dynamic = ["dependencies"]
+
+
+[tool.setuptools]
+packages = ["src"]
+dynamic.dependencies = {file = ["requirements.txt"]}
+
+
+[tool.pytest.ini_options]
+addopts = "--cov=src --cov-fail-under=80"
+testpaths = ["tests"]
+
+
+[tool.ruff]
+line-length = 80
+indent-width = 4
+target-version = "py311"
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
+[tool.ruff.lint]
+select = ["F", "I", "N", "PL", "R", "RUF", "S", "UP", "W"]
+ignore = []
+fixable = ["ALL"]
+unfixable = []
+# Allow unused variables when underscore-prefixed
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+# https://github.com/astral-sh/ruff/issues/4368
+[tool.ruff.lint.extend-per-file-ignores]
+"tests/**/*.py" = [
+    "S101",    #  Use of `assert` detected
+    "PLR2004", #  Magic value used in comparison
+    "PLR0913", #  Too many arguments in function definition
+]

--- a/src/apis/alteryx_gallery/connector_alt.py
+++ b/src/apis/alteryx_gallery/connector_alt.py
@@ -24,7 +24,7 @@ class GalleryConnector:
     @property
     def oauth_timestamp(self) -> str:
         """Example: 1637748738"""
-        return str(int(math.floor(time.time())))
+        return str(math.floor(time.time()))
 
     @property
     def oauth_signature_method(self) -> str:

--- a/src/apis/braze/connector.py
+++ b/src/apis/braze/connector.py
@@ -55,7 +55,10 @@ class BrazeConnector:
             headers=self.request_headers,
         )
 
-    def user_profile_export_by_identifier(self, body: dict) -> requests.Response:
+    def user_profile_export_by_identifier(
+        self,
+        body: dict,
+    ) -> requests.Response:
         """
         https://www.braze.com/docs/api/endpoints/export/user_data/post_users_identifier/
         """
@@ -67,7 +70,10 @@ class BrazeConnector:
             data=json.dumps(body),
         )
 
-    def user_profile_export_by_segment(self, segment_id: str) -> requests.Response:
+    def user_profile_export_by_segment(
+        self,
+        segment_id: str,
+    ) -> requests.Response:
         """
         https://www.braze.com/docs/api/endpoints/export/user_data/post_users_segment/
         """

--- a/src/apis/braze/main.py
+++ b/src/apis/braze/main.py
@@ -52,13 +52,17 @@ def main() -> None:
         ],
     }
     utils.pprint(
-        braze_connector.user_profile_export_by_identifier(body=user_export_body).json()
+        braze_connector.user_profile_export_by_identifier(
+            body=user_export_body
+        ).json()
     )
 
     # User Export by Segment
     jaja_segment = "7a09f4c1-0f7a-4dfc-8dec-bba78c73d5c9"
     utils.pprint(
-        braze_connector.user_profile_export_by_segment(segment_id=jaja_segment).json()
+        braze_connector.user_profile_export_by_segment(
+            segment_id=jaja_segment
+        ).json()
     )
 
 

--- a/src/apis/companies_house/connector.py
+++ b/src/apis/companies_house/connector.py
@@ -48,7 +48,7 @@ class CompaniesHouseConnector:
 
         https://developer-specs.company-information.service.gov.uk/guides/authorisation
         """
-        return "Basic " + base64.b64encode(f"{self.api_key}:".encode("UTF-8")).decode()
+        return "Basic " + base64.b64encode(f"{self.api_key}:".encode()).decode()
 
     @property
     def request_headers(self) -> dict:

--- a/src/apis/companies_house/main.py
+++ b/src/apis/companies_house/main.py
@@ -40,14 +40,14 @@ def main() -> None:
         "foreign_company_details",
     ]
     disallowed_officer_properties = ["former_names"]
-    company_profile_json = allica_bank.get_company_profile()
-    company_officers_json = allica_bank.get_company_officers()
+    profile_json = allica_bank.get_company_profile()
+    officers_json = allica_bank.get_company_officers()
     with contextlib.suppress(KeyError):
-        [company_profile_json.pop(key) for key in disallowed_company_properties]
-        [company_officers_json.pop(key) for key in disallowed_officer_properties]
+        [profile_json.pop(key) for key in disallowed_company_properties]
+        [officers_json.pop(key) for key in disallowed_officer_properties]
 
-    _write_json(company_profile_json, f"data/{company_number}-profile.json")
-    _write_json(company_officers_json, f"data/{company_number}-officers.json")
+    _write_json(profile_json, f"data/{company_number}-profile.json")
+    _write_json(officers_json, f"data/{company_number}-officers.json")
 
 
 if __name__ == "__main__":

--- a/src/apis/confluence/connector.py
+++ b/src/apis/confluence/connector.py
@@ -37,7 +37,7 @@ class ConfluenceConnector:
         return (
             "Basic "
             + base64.b64encode(
-                f"{self._api_key}:{self._api_secret}".encode("UTF-8")
+                f"{self._api_key}:{self._api_secret}".encode()
             ).decode()
         )
 

--- a/src/apis/gmail/main.py
+++ b/src/apis/gmail/main.py
@@ -5,7 +5,6 @@ Following instructions at
 import smtplib
 import ssl
 
-
 if __name__ == "__main__":
     smtp_server = "smtp.gmail.com"
     port = 587  # For starttls

--- a/src/apis/jira/connector.py
+++ b/src/apis/jira/connector.py
@@ -37,7 +37,7 @@ class JiraConnector:
         return (
             "Basic "
             + base64.b64encode(
-                f"{self._api_key}:{self._api_secret}".encode("UTF-8")
+                f"{self._api_key}:{self._api_secret}".encode()
             ).decode()
         )
 
@@ -122,7 +122,9 @@ class JiraConnector:
                         "content": [
                             {
                                 "type": "paragraph",
-                                "content": [{"text": description, "type": "text"}],
+                                "content": [
+                                    {"text": description, "type": "text"}
+                                ],
                             }
                         ],
                     },

--- a/src/apis/jira/main.py
+++ b/src/apis/jira/main.py
@@ -25,7 +25,9 @@ def main() -> None:
 
     utils.pprint(jira_connector.get_projects_paginated().json())
     utils.pprint(jira_connector.get_issue(issue_key="DEV-67").json())
-    utils.pprint(jira_connector.get_project_components(project_id=project_id).json())
+    utils.pprint(
+        jira_connector.get_project_components(project_id=project_id).json()
+    )
     utils.pprint(
         jira_connector.create_issue(
             project_id=project_id,

--- a/src/apis/tableau/connector.py
+++ b/src/apis/tableau/connector.py
@@ -22,7 +22,9 @@ def _parse_auth(auth_type: str) -> TableauAuthType:
         return TableauAuthType(auth_type.lower().strip())
     except ValueError as e:
         auth_types = [f"'{k.value}'" for k in TableauAuthType]
-        raise ValueError(f"Auth type must be one of {', '.join(auth_types)}") from e
+        raise ValueError(
+            f"Auth type must be one of {', '.join(auth_types)}"
+        ) from e
 
 
 class TableauConnector:
@@ -131,11 +133,16 @@ class TableauConnector:
     ###
     # Data Sources Methods
     ###
-    def query_data_source_connections(self, datasource_id: str) -> requests.Response:
+    def query_data_source_connections(
+        self,
+        datasource_id: str,
+    ) -> requests.Response:
         """
         https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_data_sources.htm#query_data_source_connections
         """
-        endpoint = f"sites/{self.site_id}/datasources/{datasource_id}/connections"
+        endpoint = (
+            f"sites/{self.site_id}/datasources/{datasource_id}/connections"
+        )
         return requests.request(
             method="GET",
             url=self.base_url + endpoint,
@@ -244,9 +251,7 @@ class TableauConnector:
         """
         https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#query_workbooks_for_user
         """
-        endpoint = (
-            f"sites/{self.site_id}/users/{user_id}/workbooks?ownedBy=true&pageSize=1000"
-        )
+        endpoint = f"sites/{self.site_id}/users/{user_id}/workbooks?ownedBy=true&pageSize=1000"
         return requests.request(
             method="GET",
             url=self.base_url + endpoint,
@@ -264,9 +269,7 @@ class TableauConnector:
 
         Only set up to change the password.
         """
-        endpoint = (
-            f"sites/{self.site_id}/workbooks/{workbook_id}/connections/{connection_id}"
-        )
+        endpoint = f"sites/{self.site_id}/workbooks/{workbook_id}/connections/{connection_id}"
         body = {
             "connection": {
                 "password": new_password,
@@ -292,7 +295,11 @@ class TableauConnector:
             data="{}",
         )
 
-    def update_workbook(self, workbook_id: str, new_owner_id: str) -> requests.Response:
+    def update_workbook(
+        self,
+        workbook_id: str,
+        new_owner_id: str,
+    ) -> requests.Response:
         """
         https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#update_workbook
 

--- a/src/apis/tableau/main.py
+++ b/src/apis/tableau/main.py
@@ -21,9 +21,8 @@ def change_objects_owner(tableau_connector: tableau.TableauConnector) -> None:
 
     # Change datasources owner
     # utils.pprint(tableau_connector.query_data_sources().text)
-    for datasource in tableau_connector.query_data_sources().json()["datasources"][
-        "datasource"
-    ]:
+    resp = tableau_connector.query_data_sources().json()
+    for datasource in resp["datasources"]["datasource"]:
         if datasource["owner"]["id"] == someone_id:
             # utils.pprint(data_source)
             utils.pprint(
@@ -34,9 +33,8 @@ def change_objects_owner(tableau_connector: tableau.TableauConnector) -> None:
             )
 
     # Change workbooks owner
-    for workbook in tableau_connector.query_workbooks_for_user(someone_id).json()[
-        "workbooks"
-    ]["workbook"]:
+    resp = tableau_connector.query_workbooks_for_user(someone_id).json()
+    for workbook in resp["workbooks"]["workbook"]:
         utils.pprint(
             tableau_connector.update_workbook(
                 workbook_id=workbook["id"],
@@ -45,26 +43,28 @@ def change_objects_owner(tableau_connector: tableau.TableauConnector) -> None:
         )
 
 
-def change_connection_passwords(tableau_connector: tableau.TableauConnector) -> None:
+def change_connection_passwords(
+    tableau_connector: tableau.TableauConnector,
+) -> None:
     """
     Change the password of database connections in Tableau.
     """
     new_password = "A1a-pB7F7jiP596ngMgj"
 
-    datasources = tableau_connector.query_data_sources().json()["datasources"][
-        "datasource"
-    ]
-    workbooks = tableau_connector.query_workbooks_for_site().json()["workbooks"][
-        "workbook"
-    ]
+    # fmt: off
+    datasources = tableau_connector.query_data_sources().json()["datasources"]["datasource"]
+    workbooks = tableau_connector.query_workbooks_for_site().json()["workbooks"]["workbook"]
+    # fmt: on
 
     # Update datasources
     for datasource in datasources:
         if datasource["type"] == "redshift":
             # utils.pprint(datasource)
-            connection_response = tableau_connector.query_data_source_connections(
-                datasource_id=datasource["id"]
-            ).json()
+            connection_response = (
+                tableau_connector.query_data_source_connections(
+                    datasource_id=datasource["id"]
+                ).json()
+            )
             # utils.pprint(connection_response)
             connections = connection_response["connections"]["connection"]
             for connection in connections:
@@ -86,7 +86,10 @@ def change_connection_passwords(tableau_connector: tableau.TableauConnector) -> 
         # utils.pprint(connection_response)
         connections = connection_response["connections"]["connection"]
         for connection in connections:
-            if connection["type"] == "redshift" and connection["userName"] == "tableau":
+            if (
+                connection["type"] == "redshift"
+                and connection["userName"] == "tableau"
+            ):
                 utils.pprint(
                     tableau_connector.update_workbook_connection(
                         workbook_id=workbook["id"],
@@ -101,7 +104,9 @@ def get_user_email_list(tableau_connector: tableau.TableauConnector) -> None:
     Get the emails for the licensed users in the server.
     """
     users = tableau_connector.get_users_on_site().json()["users"]["user"]
-    emails = [user["email"] for user in users if user["siteRole"] != "Unlicensed"]
+    emails = [
+        user["email"] for user in users if user["siteRole"] != "Unlicensed"
+    ]
     utils.pprint(emails)  # type: ignore
 
 
@@ -122,7 +127,9 @@ def main() -> None:
     utils.pprint(tableau_connector.query_data_sources().text)
     utils.pprint(tableau_connector.query_workbooks_for_site().text)
     utils.pprint(
-        tableau_connector.query_workbook_connections(agency_payments_workbook_id).text
+        tableau_connector.query_workbook_connections(
+            agency_payments_workbook_id
+        ).text
     )
 
     utils.pprint(tableau_connector.get_users_on_site().text)

--- a/src/apis/tableau/tableau_server.py
+++ b/src/apis/tableau/tableau_server.py
@@ -39,12 +39,16 @@ class TableauUser:
         """Example method to test the class"""
         with self.server.auth.sign_in(self._auth):
             all_datasources, pagination_item = self.server.datasources.get()
-            print(f"\nThere are {pagination_item.total_available} datasources on site:")
+            print(
+                f"\nThere are {pagination_item.total_available} datasources on site:"
+            )
             print([datasource.name for datasource in all_datasources])
 
     def list_workbooks(self):
         """Example method to test the class"""
         with self.server.auth.sign_in(self._auth):
             all_workbooks, pagination_item = self.server.workbooks.get()
-            print(f"\nThere are {pagination_item.total_available} workbooks on site:")
+            print(
+                f"\nThere are {pagination_item.total_available} workbooks on site:"
+            )
             print([workbook.name for workbook in all_workbooks])

--- a/src/apis/tempo/main.py
+++ b/src/apis/tempo/main.py
@@ -13,8 +13,8 @@ https://community.atlassian.com/t5/Jira-questions/What-is-the-simplest-way-to-co
 """
 
 import json
-import sys
 import os
+import sys
 
 import dotenv
 import requests
@@ -87,8 +87,11 @@ def main(
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 6:
-        raise ValueError("There was an error retrieving the latest task details.")
+    required_args = 6
+    if len(sys.argv) != required_args:
+        raise ValueError(
+            "There was an error retrieving the latest task details."
+        )
 
     main(
         issue_key=sys.argv[1],

--- a/src/apis/tfl/__init__.py
+++ b/src/apis/tfl/__init__.py
@@ -8,6 +8,6 @@ from src.apis.tfl.connector import TFLConnector
 from src.apis.tfl.model import JourneyPlannerSearchParams
 
 __all__ = [
-    "TFLConnector",
     "JourneyPlannerSearchParams",
+    "TFLConnector",
 ]

--- a/src/apis/tfl/connector.py
+++ b/src/apis/tfl/connector.py
@@ -58,7 +58,9 @@ class TFLConnector:
         https://api-portal.tfl.gov.uk/api-details#api=BikePoint
         """
         if bike_point_id and query:
-            raise ValueError("Only one of 'bike_point_id' or 'query' can be provided.")
+            raise ValueError(
+                "Only one of 'bike_point_id' or 'query' can be provided."
+            )
 
         endpoint = "BikePoint"
         if bike_point_id:
@@ -115,7 +117,10 @@ class TFLConnector:
         self,
         from_: str,
         to: str,
-        journey_planner_search_params: model.JourneyPlannerSearchParams | None = None,
+        # fmt: off
+        journey_planner_search_params: model.JourneyPlannerSearchParams
+        | None = None,
+        # fmt: on
     ) -> requests.Response:
         """
         https://api-portal.tfl.gov.uk/api-details#api=Journey

--- a/src/apis/tfl/main.py
+++ b/src/apis/tfl/main.py
@@ -16,13 +16,23 @@ def main() -> None:
     utils.pprint(tfl_connector.get_air_quality().json())
 
     utils.pprint(tfl_connector.get_bike_points().json())
-    utils.pprint(tfl_connector.get_bike_points(bike_point_id="BikePoints_608").json())
+    utils.pprint(
+        tfl_connector.get_bike_points(bike_point_id="BikePoints_608").json()
+    )
     utils.pprint(tfl_connector.get_bike_points(query="Holborn").json())
 
     # These were returning HTML?!
     print(tfl_connector.get_crowding(naptan="940GZZLUBST").text)
-    print(tfl_connector.get_crowding(naptan="940GZZLUBST", day_of_week="Live").text)
-    print(tfl_connector.get_crowding(naptan="940GZZLUBST", day_of_week="Monday").text)
+    print(
+        tfl_connector.get_crowding(
+            naptan="940GZZLUBST", day_of_week="Live"
+        ).text
+    )
+    print(
+        tfl_connector.get_crowding(
+            naptan="940GZZLUBST", day_of_week="Monday"
+        ).text
+    )
 
     utils.pprint(tfl_connector.get_journey().json())
     utils.pprint(tfl_connector.get_journey(meta=True).json())

--- a/src/apis/twilio/connector.py
+++ b/src/apis/twilio/connector.py
@@ -13,7 +13,9 @@ class TwilioConnector:
     """
 
     def __init__(self, workspace: str, api_key: str, api_secret: str):
-        self.base_url = f"https://taskrouter.twilio.com/v1/Workspaces/{workspace}/"
+        self.base_url = (
+            f"https://taskrouter.twilio.com/v1/Workspaces/{workspace}/"
+        )
         self.auth = (api_key, api_secret)
 
     @property

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,4 +1,3 @@
 import pathlib
 
-
 PROJECT_ROOT = pathlib.Path(__file__).parent.parent

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -4,7 +4,6 @@ Handy utilities for working with (REST) API data.
 
 from src.utils.utils import pprint, to_param_string
 
-
 __all__ = [
     "pprint",
     "to_param_string",

--- a/tests/apis/alteryx_gallery/test__connector.py
+++ b/tests/apis/alteryx_gallery/test__connector.py
@@ -32,7 +32,9 @@ def connection() -> connector.GalleryConnector:
     )
 
 
-def test__connector_properties_are_correct(connection: connector.GalleryConnector):
+def test__connector_properties_are_correct(
+    connection: connector.GalleryConnector,
+):
     assert connection.base_url == BASE_URL
     assert connection.request_headers == {
         "Content-Type": "application/json",

--- a/tests/apis/alteryx_gallery/test__connector_alt.py
+++ b/tests/apis/alteryx_gallery/test__connector_alt.py
@@ -32,7 +32,9 @@ class MockClient:
     def sign(self, url: str):
         return [
             f"{self},{url}",
-            {"Authorization": 'oauth_signature="4N06lp4cYi07HOB4k0kjd3xJLjo%3D"'},
+            {
+                "Authorization": 'oauth_signature="4N06lp4cYi07HOB4k0kjd3xJLjo%3D"'
+            },
         ]
 
 

--- a/tests/apis/braze/test__connector.py
+++ b/tests/apis/braze/test__connector.py
@@ -41,7 +41,9 @@ def test__invalid_brands_raise_an_error():
         )
 
 
-def test__connector_properties_are_correct(connection: connector.BrazeConnector):
+def test__connector_properties_are_correct(
+    connection: connector.BrazeConnector,
+):
     assert connection.base_url == BASE_URL
     assert connection.request_headers == {
         "Content-Type": "application/json",

--- a/tests/apis/companies_house/test__connector.py
+++ b/tests/apis/companies_house/test__connector.py
@@ -6,7 +6,9 @@ from src.apis.companies_house import connector
 
 
 @pytest.fixture
-def connection(monkeypatch: pytest.MonkeyPatch) -> connector.CompaniesHouseConnector:
+def connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> connector.CompaniesHouseConnector:
     return connector.CompaniesHouseConnector(api_key="a1b2-c3d4")
 
 
@@ -32,7 +34,9 @@ def test__search_parameters_are_built_correctly(
         request_data["url"] = url
         request_data["headers"] = headers
 
-    monkeypatch.setattr(connector, "requests", SimpleNamespace(request=mock_request))
+    monkeypatch.setattr(
+        connector, "requests", SimpleNamespace(request=mock_request)
+    )
     connection.search(q="Company Name", items_per_page=10)
 
     assert request_data["method"] == "GET"

--- a/tests/apis/confluence/test__connector.py
+++ b/tests/apis/confluence/test__connector.py
@@ -33,7 +33,9 @@ def connection() -> connector.ConfluenceConnector:
     )
 
 
-def test__connector_properties_are_correct(connection: connector.ConfluenceConnector):
+def test__connector_properties_are_correct(
+    connection: connector.ConfluenceConnector,
+):
     assert connection.base_url == BASE_URL
     assert connection.request_headers == {
         "Content-Type": "application/json",

--- a/tests/apis/metabase/test__connector.py
+++ b/tests/apis/metabase/test__connector.py
@@ -38,7 +38,9 @@ def connection(monkeypatch: pytest.MonkeyPatch) -> connector.MetabaseConnector:
     )
 
 
-def test__connector_properties_are_correct(connection: connector.MetabaseConnector):
+def test__connector_properties_are_correct(
+    connection: connector.MetabaseConnector,
+):
     assert connection.base_url == BASE_URL
     assert connection.request_headers == {
         "Content-Type": "application/json",

--- a/tests/apis/notion/test__connector.py
+++ b/tests/apis/notion/test__connector.py
@@ -10,7 +10,9 @@ def connection(monkeypatch: pytest.MonkeyPatch) -> connector.NotionConnector:
     )
 
 
-def test__connector_properties_are_correct(connection: connector.NotionConnector):
+def test__connector_properties_are_correct(
+    connection: connector.NotionConnector,
+):
     assert connection.base_url == "https://api.notion.com/v1/"
     assert connection.notion_version == "2022-06-28"
     assert connection.request_headers == {

--- a/tests/apis/slack/test__connector.py
+++ b/tests/apis/slack/test__connector.py
@@ -13,7 +13,9 @@ def connection() -> connector.SlackConnector:
     return connector.SlackConnector(WEBHOOK_URL)
 
 
-def test__connector_properties_are_correct(connection: connector.SlackConnector):
+def test__connector_properties_are_correct(
+    connection: connector.SlackConnector,
+):
     assert connection.webhook_url == WEBHOOK_URL
 
 

--- a/tests/apis/tableau/test__connector.py
+++ b/tests/apis/tableau/test__connector.py
@@ -62,9 +62,13 @@ def test__invalid_auth_type_raise_an_error():
         )
 
 
-def test__connector_properties_are_correct(connection: connector.TableauConnector):
+def test__connector_properties_are_correct(
+    connection: connector.TableauConnector,
+):
     assert connection.base_url == BASE_URL
-    assert connection.auth_type == connector.TableauAuthType.USERNAME_AND_PASSWORD
+    assert (
+        connection.auth_type == connector.TableauAuthType.USERNAME_AND_PASSWORD
+    )
     assert connection.credentials == {
         "name": "some-key",
         "password": "some-secret",

--- a/tests/apis/twilio/test__connector.py
+++ b/tests/apis/twilio/test__connector.py
@@ -33,7 +33,9 @@ def connection(monkeypatch: pytest.MonkeyPatch) -> connector.TwilioConnector:
     )
 
 
-def test__connector_properties_are_correct(connection: connector.TwilioConnector):
+def test__connector_properties_are_correct(
+    connection: connector.TwilioConnector,
+):
     assert connection.base_url == BASE_URL
     assert connection.auth == ("some-key", "some-secret")
     assert connection.request_headers == {

--- a/tests/apis/vault/test__connector.py
+++ b/tests/apis/vault/test__connector.py
@@ -48,7 +48,9 @@ def test__invalid_auth_type_raise_an_error():
         )
 
 
-def test__connector_properties_are_correct(connection: connector.VaultConnector):
+def test__connector_properties_are_correct(
+    connection: connector.VaultConnector,
+):
     assert connection.base_url == BASE_URL
     assert connection.request_headers == {
         "Content-Type": "application/json",


### PR DESCRIPTION
## Summary by Sourcery

Refactor code formatting and Python version specification across multiple files, focusing on code style consistency and CI configuration

Enhancements:
- Improve code formatting with more consistent line breaks and indentation
- Simplify some complex list comprehensions and function calls

CI:
- Update GitHub Actions workflow to use Python version from pyproject.toml
- Add pyproject.toml for project configuration and build settings

Chores:
- Remove unnecessary imports
- Standardize encoding methods
- Reorganize import orders